### PR TITLE
Add generic omitempty to all omitempty fields

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -18,11 +18,11 @@ type BoundingBox []float64
 //   included as a member of the feature object with the name "id".
 type Feature struct {
 	Type       string                 `json:"type"`
-	Id         interface{}            `json:"id,omitempty" bson:"id,omitempty"`
+	Id         interface{}            `json:"id,omitempty" "$id,omitempty"`
 	Geometry   interface{}            `json:"geometry"`
 	Properties map[string]interface{} `json:"properties"`
-	Bbox       BoundingBox            `json:"bbox,omitempty" bson:"bbox,omitempty"`
-	Crs        *CRS                   `json:"crs,omitempty" bson:"crs,omitempty"`
+	Bbox       BoundingBox            `json:"bbox,omitempty" "$bbox,omitempty"`
+	Crs        *CRS                   `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 func (t *Feature) GetGeometry() (Geometry, error) {
@@ -45,8 +45,8 @@ func NewFeature(geom Geometry, properties map[string]interface{},
 type FeatureCollection struct {
 	Type     string      `json:"type"`
 	Features []*Feature  `json:"features"`
-	Bbox     BoundingBox `json:"bbox,omitempty"`
-	Crs      *CRS        `json:"crs,omitempty"`
+	Bbox     BoundingBox `json:"bbox,omitempty" "$bbox,omitempty"`
+	Crs      *CRS        `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 func (t *FeatureCollection) AddFeatures(f ...*Feature) {

--- a/geometry.go
+++ b/geometry.go
@@ -63,7 +63,7 @@ type Geometry interface {
 type Point struct {
 	Type        string     `json:"type"`
 	Coordinates Coordinate `json:"coordinates"`
-	Crs         *CRS       `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS       `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // Add geometry to coordinates.
@@ -99,7 +99,7 @@ func NewPoint(c Coordinate) *Point {
 type MultiPoint struct {
 	Type        string      `json:"type"`
 	Coordinates Coordinates `json:"coordinates"`
-	Crs         *CRS        `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS        `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // Add geometry to MultiPoint, if paremeter will be append to coordinates
@@ -146,7 +146,7 @@ func NewMultiPoint(coordinates Coordinates) *MultiPoint {
 type LineString struct {
 	Type        string      `json:"type"`
 	Coordinates Coordinates `json:"coordinates"`
-	Crs         *CRS        `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS        `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // Add new position to LineString
@@ -197,7 +197,7 @@ func NewLineString(coordinates Coordinates) *LineString {
 type MultiLineString struct {
 	Type        string    `json:"type"`
 	Coordinates MultiLine `json:"coordinates"`
-	Crs         *CRS      `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS      `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // Add new line or line to MultiLineString
@@ -250,7 +250,7 @@ func NewMultiLineString(coordinates MultiLine) *MultiLineString {
 type Polygon struct {
 	Type        string    `json:"type"`
 	Coordinates MultiLine `json:"coordinates,float"`
-	Crs         *CRS      `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS      `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // Add new polygon  or hole to Polygon
@@ -303,7 +303,7 @@ func NewPolygon(coordinates MultiLine) *Polygon {
 type MultiPolygon struct {
 	Type        string      `json:"type"`
 	Coordinates []MultiLine `json:"coordinates"`
-	Crs         *CRS        `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs         *CRS        `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // add new polygon or hole.
@@ -362,7 +362,7 @@ func NewMultiPolygon(coordinates []MultiLine) *MultiPolygon {
 type GeometryCollection struct {
 	Type       string        `json:"type"`
 	Geometries []interface{} `json:"geometries"`
-	Crs        *CRS          `json:"crs,omitempty" bson:"crs,omitempty"`
+	Crs        *CRS          `json:"crs,omitempty" "$crs,omitempty"`
 }
 
 // new values are append


### PR DESCRIPTION
I'm using this library with the MongoDB driver "mgo". It has a function similar to json.Marshal which converts GeoJSON objects, but it doesn't follow "json: omitempty" on fields. So this is adding bbox: null and crs: null to all queries, and then my GeoJSON is not valid in MongoDB.

I was able to fix my code by adding "$field, omitempty" to all fields where "json: omitempty" is currently used. I ran `go test` and all tests pass.
