### PR TITLE
Example JSON returned invalid structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@ Go package to easy and quick create datastructure which can be serialized to geo
 
 ***
 
-## INSTALATION
+## INSTALLATION
 
-
-`go get https://github.com/kpawlik/geojson`
-
-`go install https://github.com/kpawlik/geojson`
+    $ go get https://github.com/kpawlik/geojson
+    $ go install https://github.com/kpawlik/geojson
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -16,46 +16,39 @@ Go package to easy and quick create datastructure which can be serialized to geo
 
 ## USAGE EXAMPLE
 
-    package main
+```go
+package main
 
-    import (
-        "fmt"
-        gj "github.com/kpawlik/geojson"
-    )
+import (
+    "fmt"
+    gj "github.com/kpawlik/geojson"
+)
 
-    func main() {
-        var (
-            f *gj.Feature
-        )
-        // feature
-        p := gj.NewPoint(gj.Coordinate{12, 3.123})
-        f = gj.NewFeature(p, nil, nil)
-        if gjstr, err := gj.Marshal(f); err != nil {
-            panic(err)
-        } else {
-            fmt.Println(gjstr)
-        }
-        // feature with propertises
-        props := map[string]interface{}{"name": "location", "code": 107}
-        f = gj.NewFeature(p, props, nil)
-        if gjstr, err := gj.Marshal(f); err != nil {
-            panic(err)
-        } else {
-            fmt.Println(gjstr)
-        }
-        // feature with propertises and id
-        f = gj.NewFeature(p, props, 11101)
-        if gjstr, err := gj.Marshal(f); err != nil {
-            panic(err)
-        } else {
-            fmt.Println(gjstr)
-        }
-        ls := gj.NewLineString(gj.Coordinates{{1, 1}, {2.001, 3}, {4001, 1223}})
-        f = gj.NewFeature(ls, nil, nil)
-        if gjstr, err := gj.Marshal(f); err != nil {
-            panic(err)
-        } else {
-            fmt.Println(gjstr)
-        }
+func main() {
+    fc := gj.NewFeatureCollection([]*gj.Feature {})
 
+    // feature
+    p := gj.NewPoint(gj.Coordinate{12, 3.123})
+    f1 := gj.NewFeature(p, nil, nil)
+    fc.AddFeatures(f1)
+
+    // feature with propertises
+    props := map[string]interface{}{"name": "location", "code": 107}
+    f2 := gj.NewFeature(p, props, nil)
+    fc.AddFeatures(f2)
+
+    // feature with propertises and id
+    f3 := gj.NewFeature(p, props, 11101)
+    fc.AddFeatures(f3)
+
+    ls := gj.NewLineString(gj.Coordinates{{1, 1}, {2.001, 3}, {4001, 1223}})
+    f4 := gj.NewFeature(ls, nil, nil)
+    fc.AddFeatures(f4)
+
+    if gjstr, err := gj.Marshal(fc); err != nil {
+        panic(err)
+    } else {
+        fmt.Println(gjstr)
     }
+}
+```


### PR DESCRIPTION
You were printing several Feature types on separate lines but they need to be contained within a FeatureCollection in order to be both valid GeoJSON and JSON. This simplified the code since there is just the one marshal/print at the end, now. I also created multiple value variables (rather than pointers) for the features since they are passed-in and stored as pointers. Every time we would reassign the pointer we'd effectively be updating the values that have already been added to the feature-collection as well.

I also updated the README to correctly syntax-highlight the example, to correctly show the preformatting for the installation commands, and fixed one spelling error.

Thanks for the project. From what I've seen it's simple and effective.