### PR TITLE
Made Coordinate a slice

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -34,10 +34,12 @@ func Coord(obj interface{}) (ct CoordType) {
 	return
 }
 
-// Type to represent one coordinate (x,y).
+// Type to represent one coordinate (x,y). This coordinate can have any number of dimensions per the spec.
 // To simplify create new instance.
 // c := Coordinate{x, y}
-type Coordinate [2]CoordType
+// or
+// c := Coordinate{x, y, z}
+type Coordinate []CoordType
 
 // Slice of coordinates.
 // Simply creation:


### PR DESCRIPTION
The GeoJSON "coordinate" is just an array whose definition depends on the CRS (coordinate reference system). The `Coordinate` type that is used to express coordinates only supports two elements. I changed it to be a slice.

I chiefly just wanted to have altitudes (GeoJSON defaults to the WGS84 datum as the CRS, which supports altitudes).
