### PR TITLE
Fix problem with Unmarshal Feature containing GeometryCollection

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -9,12 +9,12 @@ import (
 type BoundingBox []float64
 
 // A GeoJSON object with the type "Feature" is a feature object.
-// - A feature object must have a member with the name "geometry". 
+// - A feature object must have a member with the name "geometry".
 //	 The value of the geometry member is a geometry object or a JSON null value.
-// - A feature object must have a member with the name "properties". 
-//   The value of the properties member is an object (any JSON object 
+// - A feature object must have a member with the name "properties".
+//   The value of the properties member is an object (any JSON object
 //   or a JSON null value).
-// - If a feature has a commonly used identifier, that identifier should be 
+// - If a feature has a commonly used identifier, that identifier should be
 //   included as a member of the feature object with the name "id".
 type Feature struct {
 	Type       string                 `json:"type" bson:"type"`
@@ -30,7 +30,7 @@ func (t *Feature) GetGeometry() (Geometry, error) {
 	return parseGeometry(gi)
 }
 
-// Factory constructor method 
+// Factory constructor method
 func NewFeature(geom Geometry, properties map[string]interface{},
 	id interface{}) *Feature {
 	return &Feature{Type: "Feature",
@@ -39,8 +39,8 @@ func NewFeature(geom Geometry, properties map[string]interface{},
 		Id:         id}
 }
 
-// An object of type "FeatureCollection" must have a member with the name 
-// "features". The value corresponding to "features" is an array. 
+// An object of type "FeatureCollection" must have a member with the name
+// "features". The value corresponding to "features" is an array.
 // Each element in the array is a Feature object.
 type FeatureCollection struct {
 	Type     string      `json:"type" bson:"type"`
@@ -61,8 +61,8 @@ func NewFeatureCollection(features []*Feature) *FeatureCollection {
 	return &FeatureCollection{Type: "FeatureCollection", Features: features}
 }
 
-// The coordinate reference system (CRS) of a GeoJSON object 
-// is determined by its "crs" member. 
+// The coordinate reference system (CRS) of a GeoJSON object
+// is determined by its "crs" member.
 type CRS struct {
 	Type       string            `json:"type" bson:"type"`
 	Properties map[string]string `json:"properties" bson:"properties"`
@@ -229,7 +229,7 @@ func parseGeometry(gi interface{}) (geom Geometry, err error) {
 		case "MultiPolygon":
 			return parseMultiPolygon(coord)
 		case "GeometryCollection":
-			return parseGeometryCollection(coord)
+			return parseGeometryCollection(g["geometries"])
 		default:
 			err = errors.New(fmt.Sprintf("ParseError: Unknown geometry type %s", typ))
 			break

--- a/feature_test.go
+++ b/feature_test.go
@@ -162,8 +162,8 @@ func TestParseCoordinates(t *testing.T) {
 	if coords, err := parseCoordinates(icoords); err != nil {
 		t.Error(err)
 	} else {
-		tt.AssertEq(coords[0], Coordinate{1, 0}, "Parse first coordinate error")
-		tt.AssertEq(coords[1], Coordinate{1.1, 2}, "Parse second coordinate error")
+		tt.AssertCoordinates(coords[0], Coordinate{1, 0}, "Parse first coordinate error")
+		tt.AssertCoordinates(coords[1], Coordinate{1.1, 2}, "Parse second coordinate error")
 	}
 	_, err = parseCoordinates([][]interface{}{{"1", 1}, {"asd", 0}})
 	tt.AssertNeq(err, nil, "Error expected")
@@ -180,8 +180,8 @@ func TestParseMultiline(t *testing.T) {
 	if ml, err := parseMultiLine(icoords); err != nil {
 		t.Error(err)
 	} else {
-		tt.AssertEq(ml[0][0], Coordinate{1, 1}, "Parse first coordinate error")
-		tt.AssertEq(ml[1][1], Coordinate{4, 4}, "Parse last coordinate error")
+		tt.AssertCoordinates(ml[0][0], Coordinate{1, 1}, "Parse first coordinate error")
+		tt.AssertCoordinates(ml[1][1], Coordinate{4, 4}, "Parse last coordinate error")
 	}
 	_, err = parseCoordinates([]interface{}{1, 2})
 	tt.AssertNeq(err, nil, "Error expected")

--- a/feature_test.go
+++ b/feature_test.go
@@ -141,7 +141,8 @@ func TestUnmarshalFeatureAndGeometryCollection(t *testing.T) {
 		"geometry": {
 			"type":"GeometryCollection",
 			"geometries": [
-				{"type":"Point", "coordinates": [100,0]}
+				{"type":"Point", "coordinates": [100,0]},
+				{"type":"Point", "coordinates": [0,100]}
 			]
 		},
 		"properties":null
@@ -151,9 +152,16 @@ func TestUnmarshalFeatureAndGeometryCollection(t *testing.T) {
 	if err != nil {
 		t.Fatal("unmarshal failed")
 	}
-	_, err = f.GetGeometry()
+	g, err := f.GetGeometry()
 	if err != nil {
 		t.Fatal("GeoGeometry failed:", err)
+	}
+	gc, ok := g.(*GeometryCollection)
+	if !ok {
+		t.Fatal("expected GeometryCollection")
+	}
+	if len(gc.Geometries) != 2 {
+		t.Fatalf("expected 2 geometries in collection, got %d", len(gc.Geometries))
 	}
 }
 

--- a/feature_test.go
+++ b/feature_test.go
@@ -135,6 +135,28 @@ func TestUnmarshalFeatureAndMultiLineString(t *testing.T) {
 	tt.AssertCoordinates(mls.Coordinates[0][1], Coordinate{2, 3}, "Coordinate test 2")
 }
 
+func TestUnmarshalFeatureAndGeometryCollection(t *testing.T) {
+	res := `{
+		"type":"Feature",
+		"geometry": {
+			"type":"GeometryCollection",
+			"geometries": [
+				{"type":"Point", "coordinates": [100,0]}
+			]
+		},
+		"properties":null
+	}`
+	f := Feature{}
+	err := json.Unmarshal([]byte(res), &f)
+	if err != nil {
+		t.Fatal("unmarshal failed")
+	}
+	_, err = f.GetGeometry()
+	if err != nil {
+		t.Fatal("GeoGeometry failed:", err)
+	}
+}
+
 func TestParseCoordinate(t *testing.T) {
 	var (
 		icoord interface{}


### PR DESCRIPTION
Currently it passes `coordinates` field to `parseGeometryCollection`.